### PR TITLE
Moved boundary files to a seperate repo

### DIFF
--- a/boundaries/Geometry_ADAUID.gpkg
+++ b/boundaries/Geometry_ADAUID.gpkg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9ed9ff27ac7ec56a4673af49f97f4184ad9a22a3503342163e3caaf1abda1e72
-size 89567232

--- a/boundaries/Geometry_CANADA.gpkg
+++ b/boundaries/Geometry_CANADA.gpkg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5668e4a7289f17852e7168be407084068afb7fb9fd94a1d63e48543d8aa5e428
-size 60661760

--- a/boundaries/Geometry_CDUID.gpkg
+++ b/boundaries/Geometry_CDUID.gpkg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2bc8ceb758d99aa1559567ce2bed22bdbdd8870ed58197ea461745613571f8d1
-size 74874880

--- a/boundaries/Geometry_CSDUID.gpkg
+++ b/boundaries/Geometry_CSDUID.gpkg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2be372cf91113b77d497b46b51b4c6194c54b8d37460b02f908607069cf8c679
-size 100175872

--- a/boundaries/Geometry_ERUID.gpkg
+++ b/boundaries/Geometry_ERUID.gpkg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:232ef8fc073079d5430321d309c9269d5dde2d457b54b5ed53a8165391b878ff
-size 62406656

--- a/boundaries/Geometry_FSAUID.gpkg
+++ b/boundaries/Geometry_FSAUID.gpkg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5e99045af56283c4e7d21fd7e2079635d6c0397fd17ec446ff12363b191005f1
-size 81276928

--- a/boundaries/Geometry_SAUID.gpkg
+++ b/boundaries/Geometry_SAUID.gpkg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5af2e0800cf25f713fcaee2087841a9043904a7d5b0c3dcda5274484e477ea92
-size 421429248

--- a/boundaries/README.md
+++ b/boundaries/README.md
@@ -1,5 +1,0 @@
-# Boundaries
-
-Boundary geometries for model results in Geopackage format.
-
-For more information about Geopackage please see [https://www.geopackage.org](https://www.geopackage.org)


### PR DESCRIPTION
Moving the boundary files to their own repo to make cloning more efficient.